### PR TITLE
Update getOrderBook endpoint

### DIFF
--- a/itbit.js
+++ b/itbit.js
@@ -181,7 +181,7 @@ function executeRequest(options, callback)
 
 ItBit.prototype.getOrderBook = function(tickerSymbol, callback)
 {
-  makePublicRequest('v2', "/markets/" + tickerSymbol + "/orders", {}, callback);
+  makePublicRequest('v1', "/markets/" + tickerSymbol + "/order_book", {}, callback);
 };
 
 ItBit.prototype.getTicker = function(tickerSymbol, callback)
@@ -191,7 +191,7 @@ ItBit.prototype.getTicker = function(tickerSymbol, callback)
 
 ItBit.prototype.getTrades = function(tickerSymbol, callback)
 {
-    makePublicRequest('v1', "/markets/" + tickerSymbol + "/trades?since=0", {}, callback);
+  makePublicRequest('v1', "/markets/" + tickerSymbol + "/trades?since=0", {}, callback);
 };
 
 ItBit.prototype.getWallets = function(userId, callback)


### PR DESCRIPTION
The endpoint https://www.itbit.com/api/v2/markets/XBTUSD/orders returns 404 error, so I have updated the endpoint to API v1 instead
