### PR TITLE
Fix signature

### DIFF
--- a/itbit.js
+++ b/itbit.js
@@ -75,7 +75,7 @@ function makePrivateRequest(method, path, args, callback)
   {
     postData = JSON.stringify(args);
   }
-  else if (method === "GET")
+  else if (method === "GET" && !_.isEmpty(args))
   {
     uri += "?" + querystring.stringify(args);
   }

--- a/itbit.js
+++ b/itbit.js
@@ -86,15 +86,17 @@ function makePrivateRequest(method, path, args, callback)
   // message is concatenated string of nonce and JSON array of secret, method, uri, json_body, nonce, timestamp
   var message = nonce + JSON.stringify([method, uri, postData, nonce.toString(), timestamp.toString()]);
 
-  var hash_digest = crypto
+  var hashBuffer = crypto
       .createHash("sha256")
       .update(message).
-      digest("binary");
+      digest();
+
+  var bufferToHash = Buffer.concat([Buffer.from(uri), hashBuffer]);
 
   var signer = crypto.createHmac("sha512", self.secret);
 
   var signature = signer
-      .update(uri + hash_digest)
+      .update(bufferToHash)
       .digest("base64");
 
   var options = {


### PR DESCRIPTION
You were using an undocumented encoding option for the `digest` funtion https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding

This was generating the wrong signature for me. 

Instead I use the Buffer returned from `digest` and concat it with the buffer generated from the `uri` string.

This generates the correct signature.

Furthermore, I remove appending the string `?` to the `uri` if there is no query string to append.